### PR TITLE
LPS-66801 HttpSessionAdaptor's inner session cleanup causes unnecessa…

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
@@ -43,8 +43,33 @@ public class HttpSessionAdaptor implements HttpSession, Serializable {
 				innerSessionsToInvalidate = new HashSet<HttpSessionAdaptor>(innerSessions);
 				innerSessions.clear();
 			}
+
 			for (HttpSessionAdaptor innerSession : innerSessionsToInvalidate) {
-				innerSession.invalidate();
+				ContextController contextController =
+					innerSession.getController();
+
+				EventListeners eventListeners =
+					contextController.getEventListeners();
+
+				List<HttpSessionListener> httpSessionListeners =
+					eventListeners.get(HttpSessionListener.class);
+
+				if (!httpSessionListeners.isEmpty()) {
+					HttpSessionEvent httpSessionEvent = new HttpSessionEvent(
+						innerSession);
+
+					for (HttpSessionListener listener : httpSessionListeners) {
+						try {
+							listener.sessionDestroyed(httpSessionEvent);
+						}
+						catch (IllegalStateException ise) {
+							// outer session is already invalidated
+						}
+					}
+				}
+
+				contextController.removeActiveSession(
+					innerSession.getSession());
 			}
 		}
 


### PR DESCRIPTION
…ry IllegalStateException. When the parent is gone, it can not access its attributes, and there is no need to explicitly remove inner session again.