### PR TITLE
LPS-69940 Invoke session listeners when unregistering them. Fix ListenerRegistration.equals so it gets actually removed from available EventListener list

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Filter;
@@ -47,6 +48,7 @@ import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextAttributeListener;
+import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -2839,6 +2841,85 @@ public class ServletTest extends TestCase {
 		Assert.assertEquals(servletContext1.hashCode(), servletContext2.hashCode());
 		Assert.assertNotEquals(servletContext1.hashCode(), servletContext3.hashCode());
 		Assert.assertNotEquals(servletContext2.hashCode(), servletContext3.hashCode());
+	}
+
+	public void test_Listener11() throws Exception {
+
+		final AtomicInteger listenerBalance = new AtomicInteger(0);
+		final AtomicReference<HttpSession> sessionReference = new AtomicReference<HttpSession>();
+
+		ServletContextListener scl = new ServletContextListener() {
+			
+			@Override
+			public void contextInitialized(ServletContextEvent arg0) {
+			}
+			
+			@Override
+			public void contextDestroyed(ServletContextEvent arg0) {
+				listenerBalance.decrementAndGet();
+			}
+		};
+
+		HttpSessionListener sl = new HttpSessionListener() {
+
+			@Override
+			public void sessionDestroyed(HttpSessionEvent se) {
+				listenerBalance.incrementAndGet();
+			}
+
+			@Override
+			public void sessionCreated(HttpSessionEvent se) {
+			}
+		};
+
+		Servlet sA = new HttpServlet() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void doGet(
+				HttpServletRequest req, HttpServletResponse resp)
+				throws ServletException, IOException {
+
+				HttpSession session = req.getSession();
+				sessionReference.set(session);
+
+				session.setAttribute("testAttribute", "testValue");
+				PrintWriter writer = resp.getWriter();
+				writer.write("S11 requested");
+			}
+		};
+
+		Collection<ServiceRegistration<?>> registrations = new ArrayList<ServiceRegistration<?>>();
+		try {
+			Dictionary<String, String> scListenerProps = new Hashtable<String, String>();
+			scListenerProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_LISTENER, "true");
+			registrations.add(getBundleContext().registerService(ServletContextListener.class, scl, scListenerProps));
+
+			Dictionary<String, String> sListenerProps = new Hashtable<String, String>();
+			sListenerProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_LISTENER, "true");
+			registrations.add(getBundleContext().registerService(HttpSessionListener.class, sl, sListenerProps));
+
+			Dictionary<String, String> servletProps1 = new Hashtable<String, String>();
+			servletProps1.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "S11");
+			servletProps1.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/s11");
+			registrations.add(getBundleContext().registerService(Servlet.class, sA, servletProps1));
+
+			String result = requestAdvisor.request("s11");
+			Assert.assertEquals("S11 requested", result);
+		}
+		finally {
+			for (ServiceRegistration<?> registration : registrations) {
+				registration.unregister();
+			}
+		}
+
+		//Emulate session expiration to check sessionListener
+		//is only called once (when unregister)
+		HttpSession session = sessionReference.get();
+
+		session.invalidate();
+
+		Assert.assertEquals(0, listenerBalance.get());
 	}
 
 	public void test_Async1() throws Exception {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ContextController.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ContextController.java
@@ -15,9 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.AccessController;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import javax.servlet.*;
@@ -755,6 +753,12 @@ public class ContextController {
 				matchingFilterRegistrations.add(filterRegistration);
 			}
 		}
+	}
+
+	public Map<String, HttpSessionAdaptor> getActiveSessions() {
+		checkShutdown();
+
+		return activeSessions;
 	}
 
 	public Set<EndpointRegistration<?>> getEndpointRegistrations() {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
@@ -269,6 +269,38 @@ public class HttpSessionAdaptor implements HttpSession, Serializable {
 		controller.removeActiveSession(session);
 	}
 
+	public void invokeSessionListeners (List<Class<? extends EventListener>> classes, EventListener listener) {
+		if (classes == null) {
+			return;
+		}
+
+		for (Class<? extends EventListener> clazz : classes) {
+			if (clazz.equals(HttpSessionListener.class)){
+				HttpSessionEvent sessionEvent = new HttpSessionEvent(this);
+				HttpSessionListener httpSessionListener = (HttpSessionListener) listener;
+				httpSessionListener.sessionDestroyed(sessionEvent);
+			}
+
+			if (clazz.equals(HttpSessionBindingListener.class) || clazz.equals(HttpSessionAttributeListener.class)) {
+				Enumeration<String> attributeNames = getAttributeNames();
+				while (attributeNames.hasMoreElements()) {
+					String attributeName = attributeNames.nextElement();
+					HttpSessionBindingEvent sessionBindingEvent = new HttpSessionBindingEvent(this, attributeName);
+
+					if (clazz.equals(HttpSessionBindingListener.class)) {
+						HttpSessionBindingListener httpSessionBindingListener = (HttpSessionBindingListener) listener;
+						httpSessionBindingListener.valueUnbound(sessionBindingEvent);
+					}
+
+					if (clazz.equals(HttpSessionAttributeListener.class)) {
+						HttpSessionAttributeListener httpSessionAttributeListener = (HttpSessionAttributeListener) listener;
+						httpSessionAttributeListener.attributeRemoved(sessionBindingEvent);
+					}
+				}
+			}
+		}
+	}
+
 	/**@deprecated*/
 	public void putValue(String arg0, Object arg1) {
 		setAttribute(arg0, arg1);


### PR DESCRIPTION
Hi @rotty3000. Here is the promised PR.

So, when unregistering session listeners, Equinox is not executing those shutdown methods (sessionDestroyed, valueUnbound..), so they were executed only when invalidating sessions, which happens after all listeners are unregistered (servletContextListener included). This is wrong as Servlet 3 specification states, in section 11.3.4 (see LPS).

Additionally to this behaviour, ListenerRegistration.equals was giving false always, as we were using EventListener.equals method against a Proxy object. I changed the order so it gives true whenever it has to. This fixes event listener removal (it was never being removed before, causing multiple executions after this fix).

I added a test to check all the previous cases (of course it fails without this fix).

We need this for Liferay Faces, as we use a  servletContextListener.contextDestroyed that removes stuff needed by a session Listener.sessionDestroyed, so it was failing due to the wrong execution order. It would be great to merge this in for next GA.

Hope it makes sense.


